### PR TITLE
fix problem highlighted in #7, preserving original semantics

### DIFF
--- a/anapo/anapo.cabal
+++ b/anapo/anapo.cabal
@@ -46,7 +46,8 @@ library
     unordered-containers,
     vector,
     jsaddle,
-    ghc-prim
+    ghc-prim,
+    stm
   if !impl(ghcjs)
     build-depends:
       text

--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import subprocess
 import argparse
 


### PR DESCRIPTION
The fix in #7 removed the semantics whereby exceptions are handled
immediately. This fix keeps that semantics in place.

We resort to STM, which is probably slower than `MVar` and `Async.race`,
but on the other hand we do not use additional threads at all, which
might make up for the loss of performance... I don't think it matters
either way.